### PR TITLE
Update wikipedia.py

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -500,7 +500,7 @@ class WikipediaPage(object):
            `section_title` and the next subheading, which is often empty.
     '''
 
-    section = "== "+section_title+" =="
+    section = u"== {} ==".format(section_title)
     try:
       index = self.content.index(section) + len(section)
     except ValueError:


### PR DESCRIPTION
I modified that line to avoid a error of encoding when asking for a section which has special characters. The error was produced in the format() function, so I removed it and concatenate the Strings. If I'm not wrong it does the same effect.

If you want to try to reproduce the error, get this article for example:

```
#URL: http://es.wikipedia.org/wiki/Castillo_de_La_Mota
wikipedia.set_lang("es")
article = wikipedia.page('Castillo de la Mota')
```

Then, try to get the 3rd section, named 'Descripción':

```
article.section(article.sections[2])
```

You will get the following error:

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf3' in position 9: ordinal not in range(128)
```
