### PR TITLE
add - catch page errors when 'fullurl' is missing.

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -390,7 +390,13 @@ class WikipediaPage(object):
     else:
       self.pageid = pageid
       self.title = data['title']
-      self.url = data['fullurl']
+
+      # Catch failures when the full url is missing
+      try:
+        self.url = data['fullurl']
+      except KeyError as e:
+          raise PageError(self.title)
+
 
   def html(self):
     '''


### PR DESCRIPTION
When requesting some pages via WikipediaPage():

```
  File "/usr/local/lib/python2.7/dist-packages/wikipedia/wikipedia.py", line 224, in __init__
    self.load(redirect=redirect, preload=preload)
  File "/usr/local/lib/python2.7/dist-packages/wikipedia/wikipedia.py", line 276, in load
    self.__init__(title, redirect=redirect, preload=preload)
  File "/usr/local/lib/python2.7/dist-packages/wikipedia/wikipedia.py", line 224, in __init__
    self.load(redirect=redirect, preload=preload)
  File "/usr/local/lib/python2.7/dist-packages/wikipedia/wikipedia.py", line 296, in load
    self.url = data['fullurl']
KeyError: 'fullurl'
```

I think it may be due to case & whitespace in the article title string?  In any case, raising a PageError in this case may be more appropriate to pass back to the client.
