### PR TITLE
Don't pin to a specific version, allow for a range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 beautifulsoup4
-requests==2.3.0
+requests>=2.3.0,<3.0.0


### PR DESCRIPTION
requests 2.3.0 is the minimum version required, trust the project to be backward compatible until version 3.

References issue #50.
