### PR TITLE
dropping down `requests` dependency to 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ python:
   - 2.7
   - 3.3
   - 3.4
+env:
+  - REQUESTS=2.0.0
+  - REQUESTS=2.1.0
+  - REQUESTS=2.2.0
+  - REQUESTS=2.3.0
 install:
+  - pip install -q requests==$REQUESTS
   - pip install -r requirements.txt
   - pip install -e .
 script: python -m unittest discover tests/ '*test.py'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 beautifulsoup4
-requests>=2.3.0,<3.0.0
+requests>=2.0.0,<3.0.0


### PR DESCRIPTION
re https://github.com/goldsmith/Wikipedia/issues/55
- updated requirements.txt with min of 2.0.0
- updated .travis.yml to test on 2.0.0, 2.1.0, 2.2.0, 2.3.0

I _think_ the `travis` file should be correct.  that's the recommended approach in the docs;  I don't have a travis-ci.org account to test though (I should!)
