### PR TITLE
Re-use the same requests session

### DIFF
--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -7,8 +7,11 @@ class TestSession(unittest.TestCase):
   def test_session(self):
     """ Test the new_session function """
     wikipedia.new_session()
-    s1 = wikipedia.get_session()
+    s1 = wikipedia.wikipedia.SESSION
+    self.assertIsNotNone(s1)
+
     wikipedia.new_session()
-    s2 = wikipedia.get_session()
+    s2 = wikipedia.wikipedia.SESSION
+    self.assertIsNotNone(s2)
 
     self.assertNotEqual(s1, s2)

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -757,7 +757,3 @@ def new_session():
   '''
   global SESSION
   SESSION = requests.Session()
-
-def get_session():
-  # this seems to be necessary to get at the session for unit tests.
-  return SESSION


### PR DESCRIPTION
Reduce the number of http connections the requests library makes to Wikipedia by re-using a single connection.  
