### PR TITLE
Fix continued_query not actually continuing its queries

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -423,10 +423,10 @@ class WikipediaPage(object):
         for datum in pages[self.pageid][prop]:
           yield datum
 
-      if 'continue' not in request:
+      if 'query-continue' not in request:
         break
 
-      last_continue = request['continue']
+      last_continue = request['query-continue'][prop]
 
   @property
   def __title_query_param(self):


### PR DESCRIPTION
`__continued_query()` is intended to use the Wiki `plcontinue` API to continue queries which exceed the length limits of the API. This is necessary to, for example, request more than 500 links from a single page. However, the existing code does not seem to implement this correctly, and only 500 links from a single page are ever returned, as discussed in #71. 

This issue can be verified by running the following:

```
>>> print(len(wikipedia.page('List of common fish names').links))
```

Prior to this patch, the output is 500; after the patch, all 1273 links are returned. 

I believe this closes #71 and closes #65  