### PR TITLE
sections API call requires "page" and not "titles" as a key

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -643,7 +643,7 @@ class WikipediaPage(object):
         'action': 'parse',
         'prop': 'sections',
       }
-      query_params.update(self.__title_query_param)
+      query_params.update({'page': self.title})
 
       request = _wiki_request(query_params)
       self._sections = [section['line'] for section in request['parse']['sections']]


### PR DESCRIPTION
Fixes issue 77. I'm not sure whether it is the best way to do it (without using a getattr()), but it does seem to work.