### PR TITLE
Update wikipedia.py

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -642,8 +642,8 @@ class WikipediaPage(object):
       query_params = {
         'action': 'parse',
         'prop': 'sections',
+        'page': self.title,
       }
-      query_params.update(self.__title_query_param)
 
       request = _wiki_request(query_params)
       self._sections = [section['line'] for section in request['parse']['sections']]


### PR DESCRIPTION
page.sections would always return an empty list. Looking at API, I saw that 'titles' is not recognized when 'action': 'parse'.
Currently not dealing with pageId.
