### PR TITLE
Specify HTML parser for BeautifulSoup to supress warnings.

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -386,7 +386,7 @@ class WikipediaPage(object):
       request = _wiki_request(query_params)
       html = request['query']['pages'][pageid]['revisions'][0]['*']
 
-      lis = BeautifulSoup(html).find_all('li')
+      lis = BeautifulSoup(html, "lxml").find_all('li')
       filtered_lis = [li for li in lis if not 'tocsection' in ''.join(li.get('class', []))]
       may_refer_to = [li.a.get_text() for li in filtered_lis if li.a]
 

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -386,7 +386,7 @@ class WikipediaPage(object):
       request = _wiki_request(query_params)
       html = request['query']['pages'][pageid]['revisions'][0]['*']
 
-      lis = BeautifulSoup(html, "lxml").find_all('li')
+      lis = BeautifulSoup(html, "html.parser").find_all('li')
       filtered_lis = [li for li in lis if not 'tocsection' in ''.join(li.get('class', []))]
       may_refer_to = [li.a.get_text() for li in filtered_lis if li.a]
 


### PR DESCRIPTION
Since at least 4.4.1, BeautifulSoup prints a warning if you don't explicitly specify the parser

>/usr/lib64/python2.7/site-packages/bs4/__init__.py:166: UserWarning: No parser w
as explicitly specified, so I'm using the best available HTML parser for this sy
stem ("lxml"). This usually isn't a problem, but if you run this code on another
 system, or in a different virtual environment, it may use a different parser an
d behave differently.

>To get rid of this warning, change this:

> BeautifulSoup([your markup])

>to this:

> BeautifulSoup([your markup], "lxml")

This occurs when returning a list, which is parsed by BeautifulSoup.

As specified in the warning, I've updated the BeautifulSoup line to specify the parser used. I've used the python built-in html.parser rather than lxml so that no extra packages are required. lxml may be slightly faster (though there were no consistent differences in speed in my tests) and handles invalid HTML differently, but this should make no difference for it's uses in wikipedia, so I think it's better to use the default parser.