### PR TITLE
Correct suggestions

### DIFF
--- a/tests/request_mock_data.py
+++ b/tests/request_mock_data.py
@@ -40,6 +40,12 @@ mock_data = {
     (('limit', 1), ('list', 'search'), ('srinfo', 'suggestion'), ('srlimit', 1), ('srprop', ''), ('srsearch', 'butteryfly')):
     {'query-continue': {'search': {'sroffset': 1}}, 'query': {'searchinfo': {'suggestion': 'butterfly'}, 'search': [{'ns': 0, 'title': "Butterfly's Tongue"}]}, 'warnings': {'main': {'*': "Unrecognized parameter: 'limit'"}}},
 
+    ((u'limit', 1), (u'list', u'search'), (u'srinfo', u'suggestion'), (u'srlimit', 1), (u'srprop', u''), (u'srsearch', u'butterfly')):
+      {'query-continue': {'search': {'sroffset': 1}}, 'query': {'search': [{'ns': 0, 'title': "Butterfly"}]}, 'warnings': {'main': {'*': "Unrecognized parameter: 'limit'"}}},
+
+    (('inprop', 'url'), ('ppprop', 'disambiguation'), ('prop', 'info|pageprops'), ('redirects', ''), ('titles', 'Butterfly')):
+    {'query': {'pages': {'48338': {'lastrevid': 566847704, 'pageid': 48338, 'title': 'Butterfly',  'editurl': 'http://en.wikipedia.org/w/index.php?title=Butterfly&action=edit', 'counter': '', 'length': 60572, 'contentmodel': 'wikitext', '    pagelanguage': 'en', 'touched': '2013-08-07T11:15:37Z', 'ns': 0, 'fullurl': 'http://en.wikipedia.org/wiki/Butterfly'}}}},
+
     (('inprop', 'url'), ('ppprop', 'disambiguation'), ('prop', 'info|pageprops'), ('redirects', ''), ('titles', 'butterfly')):
     {'query': {'normalized': [{'to': 'Butterfly', 'from': 'butterfly'}], 'pages': {'48338': {'lastrevid': 566847704, 'pageid': 48338, 'title': 'Butterfly',  'editurl': 'http://en.wikipedia.org/w/index.php?title=Butterfly&action=edit', 'counter': '', 'length': 60572, 'contentmodel': 'wikitext', '    pagelanguage': 'en', 'touched': '2013-08-07T11:15:37Z', 'ns': 0, 'fullurl': 'http://en.wikipedia.org/wiki/Butterfly'}}}},
 

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -268,11 +268,22 @@ def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=Fals
   if title is not None:
     if auto_suggest:
       results, suggestion = search(title, results=1, suggestion=True)
+
+      if suggestion:
+        return page(
+          title=suggestion,
+          pageid=pageid,
+          auto_suggest=auto_suggest,
+          redirect=redirect,
+          preload=preload
+        )
+
       try:
-        title = suggestion or results[0]
+        title = results[0]
       except IndexError:
-        # if there is no suggestion or search results, the page doesn't exist
+        # if there are no search results, the page doesn't exist
         raise PageError(title)
+
     return WikipediaPage(title, redirect=redirect, preload=preload)
   elif pageid is not None:
     return WikipediaPage(pageid=pageid, preload=preload)


### PR DESCRIPTION
As pointed in issue #108 

This modifies the current behavior of the `auto_suggest` option of `wikipedia.page()`: if a spelling correction is provided by Wikipedia, then relaunch the search with that spelling, otherwise use the first search result.

Testing data (*mock data*) was modified accordingly.