### PR TITLE
Fixed problem with hidden files in article

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -547,7 +547,7 @@ class WikipediaPage(object):
           'prop': 'imageinfo',
           'iiprop': 'url',
         })
-        if 'imageinfo' in page
+        if 'imageinfo' in page and 'url' in page['imageinfo'][0]
       ]
 
     return self._images


### PR DESCRIPTION
Error appeared while trying to get 'images' from articles which contain hidden files. For example calling `wikipedia.WikipediaPage('One Two Three... Infinity').images` caused an error.
I also considered using `'and filehidden' not in page['imageinfo'][0]`, but this one seems more generic. I'm not really sure which is better in this case.