### PR TITLE
Add a timeout to all requests

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -16,6 +16,7 @@ API_URL = 'http://en.wikipedia.org/w/api.php'
 RATE_LIMIT = False
 RATE_LIMIT_MIN_WAIT = None
 RATE_LIMIT_LAST_CALL = None
+TIMEOUT = 10
 USER_AGENT = 'wikipedia (https://github.com/goldsmith/Wikipedia/)'
 
 
@@ -734,7 +735,7 @@ def _wiki_request(params):
     wait_time = (RATE_LIMIT_LAST_CALL + RATE_LIMIT_MIN_WAIT) - datetime.now()
     time.sleep(int(wait_time.total_seconds()))
 
-  r = requests.get(API_URL, params=params, headers=headers)
+  r = requests.get(API_URL, params=params, headers=headers, timeout=TIMEOUT)
 
   if RATE_LIMIT:
     RATE_LIMIT_LAST_CALL = datetime.now()


### PR DESCRIPTION
An application using this module can hang indefinitely if, for whatever reason, the HTTP(S) requests are not successful. I had the problem and it is difficult to debug, since there are no errors displayed and the app continues to run without doing anything.

Wikipedia is (smartly) using the [Requests](https://github.com/kennethreitz/requests) framework, but does not follow this advice given in [the documentation](http://docs.python-requests.org/en/master/user/quickstart/#timeouts) :
> You can tell Requests to stop waiting for a response after a given number of seconds with the timeout parameter. Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely.

I've added the `timeout` parameter, with a value of 10 seconds, in the `requests.get()` call where all the need to fetch data from HTTP converge.
At least it rendered my problem manageable by giving me feedback when my requests where stalling.