### PR TITLE
Remove 'limit' from search_params

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -94,7 +94,6 @@ def search(query, results=10, suggestion=False):
     'list': 'search',
     'srprop': '',
     'srlimit': results,
-    'limit': results,
     'srsearch': query
   }
   if suggestion:


### PR DESCRIPTION
'limit' is an unrecognized parameter according to the response warning ("warnings":{"main":{"*":"Unrecognized parameter: limit."}}).