### PR TITLE
try-except clause to get page's coordinates

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -566,10 +566,10 @@ class WikipediaPage(object):
 
       request = _wiki_request(query_params)
 
-      if 'query' in request:
+      try:
         coordinates = request['query']['pages'][self.pageid]['coordinates']
         self._coordinates = (Decimal(coordinates[0]['lat']), Decimal(coordinates[0]['lon']))
-      else:
+      except KeyError:
         self._coordinates = None
 
     return self._coordinates


### PR DESCRIPTION
On pages without coordinates, such as person pages, trying to get the coordinates would result `KeyError: 'coordinates'`.

I fixed this by changing the if clause into a try-except clause.  That's more pythonic anyways.