### PR TITLE
fix suggestion vs real result issue

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -269,7 +269,7 @@ def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=Fals
     if auto_suggest:
       results, suggestion = search(title, results=1, suggestion=True)
       try:
-        title = suggestion or results[0]
+        title = results[0] or suggestion
       except IndexError:
         # if there is no suggestion or search results, the page doesn't exist
         raise PageError(title)


### PR DESCRIPTION
[Related issue](https://github.com/goldsmith/Wikipedia/issues/176), [StackOverflow source](https://stackoverflow.com/questions/50601633/loading-page-from-wikipedia-search-query-errors-when-page-exists).

When a suggestion is found it override accurate page. This fix it.

_Yea, my branch name is longer than my fix._