### PR TITLE
Fixed url value missing in images property function

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -547,7 +547,7 @@ class WikipediaPage(object):
           'prop': 'imageinfo',
           'iiprop': 'url',
         })
-        if 'imageinfo' in page
+        if 'imageinfo' in page and 'url' in page['imageinfo'][0]
       ]
 
     return self._images


### PR DESCRIPTION
This is a fix to Issue #193
I don't now why the error is happening, this fix only ignores it.