### PR TITLE
use dict.get() call when retrieving props form page

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -420,7 +420,7 @@ class WikipediaPage(object):
         for datum in pages.values():  # in python 3.3+: "yield from pages.values()"
           yield datum
       else:
-        for datum in pages[self.pageid][prop]:
+        for datum in pages[self.pageid].get(prop, []):
           yield datum
 
       if 'continue' not in request:


### PR DESCRIPTION
Use `dict.get()` method to avoid `KeyError` when a page has no external links. The `WikipediaPage.references` property will return a blank list instead when this happens. 

Fixes issue https://github.com/goldsmith/Wikipedia/issues/93
