### PR TITLE
Travis CI: Test on current Python and current Requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: xenial
 language: python
 python:
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: python
 python:
   - 2.7
-  - 3.3
-  - 3.4
+  - 3.6
+  - 3.8
 env:
-  - REQUESTS=2.0.0
-  - REQUESTS=2.1.0
-  - REQUESTS=2.2.0
-  - REQUESTS=2.3.0
+  - REQUESTS=2.24.0
 install:
   - pip install -q requests==$REQUESTS
   - pip install -r requirements.txt


### PR DESCRIPTION
To reenable Travis CI, visit  https://travis-ci.org/github/goldsmith/Wikipedia, and under `More options` in the upper right, select `Trigger build` on master.  After that, it should be automatic.