### PR TITLE
Prevent PageError from being raised unnecessarily

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -269,7 +269,7 @@ def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=Fals
     if auto_suggest:
       results, suggestion = search(title, results=1, suggestion=True)
       try:
-        title = suggestion or results[0]
+        title == suggestion or results[0]
       except IndexError:
         # if there is no suggestion or search results, the page doesn't exist
         raise PageError(title)


### PR DESCRIPTION
For example page('GG Allin') returns PageError 'gg all in' despite 'GG Allin' being an actual page. This change fixes the error.