### PR TITLE
docs: fix simple typo, maxmimum -> maximum

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -86,7 +86,7 @@ def search(query, results=10, suggestion=False):
 
   Keyword arguments:
 
-  * results - the maxmimum number of results returned
+  * results - the maximum number of results returned
   * suggestion - if True, return results and suggestion (if any) in a tuple
   '''
 


### PR DESCRIPTION
There is a small typo in wikipedia/wikipedia.py.

Should read `maximum` rather than `maxmimum`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md