### PR TITLE
Fix title retrieval in page function.

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -269,7 +269,7 @@ def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=Fals
     if auto_suggest:
       results, suggestion = search(title, results=1, suggestion=True)
       try:
-        title = suggestion or results[0]
+        title = results[0] or suggestion
       except IndexError:
         # if there is no suggestion or search results, the page doesn't exist
         raise PageError(title)


### PR DESCRIPTION
# Problem
- `wikipedia.summary()` raises error on common words `if auto_suggest is set to True(which is by default)`.
- Also see #284, #279, #266 for more details.
- In simple words if you use `wikipedia.summary("loki")` then it will raise `wikipedia.exceptions.DisambiguationError`: `"lok"` may refer to: . Which suggests that it is searching for `lok` instead of `loki`.

# Cause of Problem
- When calling the `summary` function, it calls the `page` function. where is auto_suggest is true then we try to check for the valid title through `search` function which return the `results and suggestion`.
- But while assigning the title variable `title = suggestion or results[0]` like this we are applying the `suggestion first` and if suggestion not found then result. Which causes this problem.
- Actually `title = results[0] or suggestion` should be used which means set title to `results[0] first` and if results[0] is not available then set it to suggestion.

# Changes
- At file  wikipedia/wikipedia.py line 272
```diff
- suggestion or results[0]
+ results[0] or suggestion
```

# Fixes
- #284
- #279
- #266