### PR TITLE
Update wikipedia.py to fix suggestion in page function.

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -269,7 +269,7 @@ def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=Fals
     if auto_suggest:
       results, suggestion = search(title, results=1, suggestion=True)
       try:
-        title = suggestion or results[0]
+        title = results[0] if results[0] == title else suggestion
       except IndexError:
         # if there is no suggestion or search results, the page doesn't exist
         raise PageError(title)


### PR DESCRIPTION
If you tried to search for 'ireland' with the auto_suggest=True, the title was set to 'island' because the suggestion='island' and results[0]='ireland'. Thus suggestion or results[0] = suggestion. Shouldn't the expected behavior title be 'ireland' if you searched for 'ireland', even with auto_suggest=True. A small change but make a difference in my opinion.

P.S. reversing the order doesn't work because of you made a spelling mistake, for instance 'ieland', the title will be set to something completely different, 'Jimmy MacCarthy' in that case. I that case you what the suggestion as the title, as in that example the suggestion is actually 'ireland'.