### PR TITLE
Return exact page title match instead of suggestion if it exists.

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -268,11 +268,7 @@ def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=Fals
   if title is not None:
     if auto_suggest:
       results, suggestion = search(title, results=1, suggestion=True)
-      try:
-        title = suggestion or results[0]
-      except IndexError:
-        # if there is no suggestion or search results, the page doesn't exist
-        raise PageError(title)
+      title = results[0] if results else suggestion      
     return WikipediaPage(title, redirect=redirect, preload=preload)
   elif pageid is not None:
     return WikipediaPage(pageid=pageid, preload=preload)


### PR DESCRIPTION
Fixes #279 and related.

There are already at least four proposed fixes to this bug ( #305 #297 #287 #253 ), but none of them quite succeed so here's a fourth attempt. Of course, considering the maintainer hasn't been seen since 2018 I doubt there's going to be any movement on any of them.