### PR TITLE
Bugfix: API prefers suggestion over result

### DIFF
--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -269,7 +269,7 @@ def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=Fals
     if auto_suggest:
       results, suggestion = search(title, results=1, suggestion=True)
       try:
-        title = suggestion or results[0]
+        title = results[0] or suggestion
       except IndexError:
         # if there is no suggestion or search results, the page doesn't exist
         raise PageError(title)


### PR DESCRIPTION
### The bug:
In wikipedia.py, some queries may cause bad results. 
**For example, running the following query:**
```
import wikipedia as w
w.page("dog")
```
Produces the following error:
```
  lis = BeautifulSoup(html).find_all('li')
Traceback (most recent call last):
  File "C:\Users\...\PycharmProjects\wikipedia_test\main.py", line 13, in <module>
    main()
  File "C:\Users\...\PycharmProjects\wikipedia_test\main.py", line 7, in main
    a = w.page("dog")
  File "C:\Users\...\PycharmProjects\wikipedia_test\venv\lib\site-packages\wikipedia\wikipedia.py", line 276, in page
    return WikipediaPage(title, redirect=redirect, preload=preload)
  File "C:\Users\...\PycharmProjects\wikipedia_test\venv\lib\site-packages\wikipedia\wikipedia.py", line 299, in __init__
    self.__load(redirect=redirect, preload=preload)
  File "C:\Users\...\PycharmProjects\wikipedia_test\venv\lib\site-packages\wikipedia\wikipedia.py", line 393, in __load
    raise DisambiguationError(getattr(self, 'title', page['title']), may_refer_to)
wikipedia.exceptions.DisambiguationError: "do" may refer to: 
do-support
Do (kana)
Ditto mark
Đỗ
Do (surname)
D.O. (entertainer)
D.O. (rapper)
Do (singer)
Marshall Applewhite
The Dø
Do (Do album)
Do (Psychostick album)
C (musical note)
Delta Omicron
solfège
buk (drum)
The White Stripes (album)
The DO
Dansgaard–Oeschger event
Delta Omega
Doctor of Osteopathic Medicine
Dissolved oxygen
.do
Dornier Flugzeugwerke
GNOME Do
kendo armor
Do (province)
Do (administrative division)
Do (Berkovići)
Do (Hadžići)
Do, Stolac
Do (Trebinje)
Do, Ivory Coast
Dominican Republic
DO (film)
Dō (philosophy)
Delivery order
Denominación de origen
Directorate of Operations (CIA)
Dominicana de Aviación
duodecimal
D0 (disambiguation)
Doe (disambiguation)
Doo (disambiguation)
Doh (disambiguation)
```
The source of the error is the fact that the library prefers showing suggestions over resl results, as in wikipedia.py:272:
```
title = suggestion or results[0] 
```
### After Fix
The result is correct!
The following code:
```
import wikipedia as w
a = w.page("dog")
print(a.title)
```
Produces a correct result:
```
Dog
```
