### PR TITLE
make auto suggest false by default

### DIFF
--- a/tests/page_test.py
+++ b/tests/page_test.py
@@ -71,7 +71,7 @@ class TestPageSetUp(unittest.TestCase):
   def test_auto_suggest(self):
     """Test that auto_suggest properly corrects a typo."""
     # yum, butter.
-    butterfly = wikipedia.page("butteryfly")
+    butterfly = wikipedia.page("butteryfly", auto_suggest=True)
 
     self.assertEqual(butterfly.title, "Butterfly")
     self.assertEqual(butterfly.url, "http://en.wikipedia.org/wiki/Butterfly")

--- a/wikipedia/wikipedia.py
+++ b/wikipedia/wikipedia.py
@@ -212,7 +212,7 @@ def random(pages=1):
 
 
 @cache
-def summary(title, sentences=0, chars=0, auto_suggest=True, redirect=True):
+def summary(title, sentences=0, chars=0, auto_suggest=False, redirect=True):
   '''
   Plain text summary of the page.
 
@@ -251,7 +251,7 @@ def summary(title, sentences=0, chars=0, auto_suggest=True, redirect=True):
   return summary
 
 
-def page(title=None, pageid=None, auto_suggest=True, redirect=True, preload=False):
+def page(title=None, pageid=None, auto_suggest=False, redirect=True, preload=False):
   '''
   Get a WikipediaPage object for the page with title `title` or the pageid
   `pageid` (mutually exclusive).


### PR DESCRIPTION
Auto suggest often returns nonsense results ("David Hume" becomes "david home", "Plato" becomes "plto" and before you say who cares about philosophers "Harry Potter" becomes "harry plotter"). There are a number of issues opened for this include
https://github.com/goldsmith/Wikipedia/issues/340
https://github.com/goldsmith/Wikipedia/issues/342
https://github.com/goldsmith/Wikipedia/issues/289

At the very least this should be made false by default.